### PR TITLE
feat: revalidation cron changed to gbfs

### DIFF
--- a/src/app/api/revalidate/route.spec.ts
+++ b/src/app/api/revalidate/route.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { POST } from './route';
+import { GET, POST } from './route';
 import { revalidatePath, revalidateTag } from 'next/cache';
 
 // Mock Next.js cache
@@ -14,6 +14,96 @@ jest.mock('next/cache', () => ({
 jest.mock('../../../i18n/routing', () => ({
   AVAILABLE_LOCALES: ['en', 'fr'],
 }));
+
+describe('GET /api/revalidate', () => {
+  const mockRevalidatePath = revalidatePath as jest.MockedFunction<
+    typeof revalidatePath
+  >;
+  const mockRevalidateTag = revalidateTag as jest.MockedFunction<
+    typeof revalidateTag
+  >;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 500 when CRON_SECRET is not configured', async () => {
+    delete process.env.CRON_SECRET;
+
+    const request = new Request('http://localhost:3000/api/revalidate', {
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer some-secret',
+      },
+    });
+
+    const response = await GET(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(json).toEqual({
+      ok: false,
+      error: 'Server misconfigured: CRON_SECRET missing',
+    });
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+    expect(mockRevalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when authorization header does not match', async () => {
+    process.env.CRON_SECRET = 'correct-secret';
+
+    const request = new Request('http://localhost:3000/api/revalidate', {
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer wrong-secret',
+      },
+    });
+
+    const response = await GET(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json).toEqual({
+      ok: false,
+      error: 'Unauthorized',
+    });
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+    expect(mockRevalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('revalidates only GBFS feed pages for authorized cron requests', async () => {
+    process.env.CRON_SECRET = 'test-secret';
+
+    const request = new Request('http://localhost:3000/api/revalidate', {
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer test-secret',
+      },
+    });
+
+    const response = await GET(request);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toEqual({
+      ok: true,
+      message: 'All GBFS feeds revalidated successfully',
+    });
+    expect(mockRevalidateTag).toHaveBeenCalledWith('feed-type-gbfs', 'max');
+    expect(mockRevalidatePath).toHaveBeenCalledWith(
+      '/[locale]/feeds/gbfs/[feedId]',
+      'layout',
+    );
+    expect(mockRevalidateTag).toHaveBeenCalledTimes(1);
+    expect(mockRevalidatePath).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('POST /api/revalidate', () => {
   const mockRevalidatePath = revalidatePath as jest.MockedFunction<

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -29,9 +29,9 @@ const defaultRevalidateOptions: RevalidateBody = {
 };
 
 /**
- * GET handler for the Vercel cron job that revalidates all feed pages once a day.
+ * GET handler for the Vercel cron job that revalidates all GBFS feed pages.
  * Vercel automatically passes Authorization: Bearer <CRON_SECRET> with each invocation.
- * Configured in vercel.json under "crons" (schedule: 0 9 * * * = 4am EST / 9am UTC).
+ * Configured in vercel.json under "crons" for 4am UTC Monday-Saturday and 7am UTC Sunday.
  */
 export async function GET(req: Request): Promise<NextResponse> {
   const authHeader = req.headers.get('authorization');
@@ -52,13 +52,13 @@ export async function GET(req: Request): Promise<NextResponse> {
   }
 
   try {
-    revalidateAllFeeds();
+    revalidateAllGbfsFeeds();
     console.log(
-      '[cron] revalidate /api/revalidate: all-feeds revalidation triggered',
+      '[cron] revalidate /api/revalidate: all-gbfs-feeds revalidation triggered',
     );
     return NextResponse.json({
       ok: true,
-      message: 'All feeds revalidated successfully',
+      message: 'All GBFS feeds revalidated successfully',
     });
   } catch (error) {
     console.error(

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,11 @@
   "crons": [
     {
       "path": "/api/revalidate",
-      "schedule": "0 9 * * *"
+      "schedule": "0 4 * * 1-6"
+    },
+    {
+      "path": "/api/revalidate",
+      "schedule": "0 7 * * 0"
     }
   ]
 }


### PR DESCRIPTION
**Summary:**

part 1/3 of #67 

Changes the revalidation cron from revalidating everything to just gbfs feeds. gtfs and gtfs_rt are going to be revalidated outside of this system

**Expected behavior:** 

From monday to saturday at 4am utc and on sunday 7am utc we will revalidate all the gbfs feed cache. From mon-sat is the estimated time of validation finishing in GCP, and on sunday is the estimated time of geolocation finishing

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `yarn test` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
