### PR TITLE
fix: improved gtfs visualization map readability

### DIFF
--- a/src/app/Theme.ts
+++ b/src/app/Theme.ts
@@ -17,6 +17,7 @@ declare module '@mui/material/styles' {
   interface Theme {
     map: {
       basemapTileUrl: string;
+      basemapTileOverallColor?: string;
       routeColor: string;
       routeTextColor: string;
     };
@@ -25,6 +26,7 @@ declare module '@mui/material/styles' {
   interface ThemeOptions {
     map?: {
       basemapTileUrl?: string;
+      basemapTileOverallColor?: string;
       routeColor?: string;
       routeTextColor?: string;
     };
@@ -138,6 +140,7 @@ export const getTheme = (mode: ThemeModeEnum): Theme => {
       basemapTileUrl: isLightMode
         ? 'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'
         : 'https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+      basemapTileOverallColor: isLightMode ? '#f6f6f6' : '#0d0d0d',
       routeColor: chosenPalette.background.default,
       routeTextColor: chosenPalette.text.primary,
     },

--- a/src/app/components/GtfsVisualizationMap.functions.tsx
+++ b/src/app/components/GtfsVisualizationMap.functions.tsx
@@ -43,6 +43,8 @@ export function extractRouteIds(val: RouteIdsInput): string[] {
 
 export function generateStopColorExpression(
   routeIdToColor: Record<string, string>,
+  mapBgColor: string,
+  altColor: string,
   fallback: string = '#888',
 ): string | ExpressionSpecification {
   const expression: Array<string | ExpressionSpecification> = [];
@@ -50,13 +52,33 @@ export function generateStopColorExpression(
   const isHex = (s: string): boolean =>
     /^[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/.test(s);
 
+  const toFullHex = (hex: string): string =>
+    hex.length === 3
+      ? `#${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
+      : `#${hex}`;
+
+  const contrastRatio = (lum1: number, lum2: number): number =>
+    (Math.max(lum1, lum2) + 0.05) / (Math.min(lum1, lum2) + 0.05);
+
+  const bgLum = linearLuminance(mapBgColor);
+  const altLum = linearLuminance(altColor);
+
   for (const [routeId, raw] of Object.entries(routeIdToColor)) {
     if (raw == null) continue;
     const hex = String(raw).trim().replace(/^#/, '');
     if (!isHex(hex)) continue; // skip empty/invalid colors
 
+    const fullHex = toFullHex(hex);
+    const routeLum = linearLuminance(fullHex);
+    const crBg = contrastRatio(routeLum, bgLum); // route vs map bg
+    const crAlt = contrastRatio(routeLum, altLum); // route vs alt color
+
+    // Same logic as route outline: use route color when it contrasts more against the bg,
+    // fall back to altColor when altColor contrasts more against the route
+    const chosenColor = crBg >= crAlt ? fullHex : altColor;
+
     // route_ids is a string of quoted ids; keep your quoted match style
-    expression.push(['in', `"${routeId}"`, ['get', 'route_ids']], `#${hex}`);
+    expression.push(['in', `"${routeId}"`, ['get', 'route_ids']], chosenColor);
   }
 
   // If nothing valid was added, just use the fallback color directly
@@ -66,6 +88,99 @@ export function generateStopColorExpression(
 
   expression.push(fallback);
   return ['case', ...expression] as ExpressionSpecification;
+}
+
+/**
+ * Simplified relative luminance (linear approximation, 0–1 range).
+ * Uses the Rec. 709 coefficients without sRGB gamma correction
+ * (MapLibre expressions don't support `pow`).
+ */
+function linearLuminance(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+}
+
+/**
+ * Builds a MapLibre expression that picks the outline color for a route line
+ * by computing simplified contrast ratios against two candidate colours
+ * (`mapBgColor` and `altOutlineColor`) and choosing the one with the
+ * higher contrast.
+ *
+ * This handles both light-on-light (e.g. white route on white map) and
+ * dark-on-dark (e.g. black route on dark outline) scenarios.
+ */
+export function generateRouteOutlineColorExpression(
+  mapBgColor: string,
+  altOutlineColor: string,
+): ExpressionSpecification {
+  // Luminance of the two candidate outline colours (precomputed at build time)
+  const bgLum = linearLuminance(mapBgColor);
+  const altLum = linearLuminance(altOutlineColor);
+
+  // Parse the feature's route_color (stored as hex without '#') into RGBA
+  const routeColorExpr: ExpressionSpecification = [
+    'to-color',
+    ['concat', '#', ['get', 'route_color']],
+    '#000000', // fallback when route_color is missing/invalid
+  ];
+
+  // Route luminance computed at render time (0–1)
+  const lumExpr: ExpressionSpecification = [
+    '/',
+    [
+      '+',
+      ['*', 0.2126, ['at', 0, ['var', 'rgba']]],
+      [
+        '+',
+        ['*', 0.7152, ['at', 1, ['var', 'rgba']]],
+        ['*', 0.0722, ['at', 2, ['var', 'rgba']]],
+      ],
+    ],
+    255,
+  ];
+
+  // Contrast ratio: CR = (Lmax + 0.05) / (Lmin + 0.05)
+  const crBgExpr: ExpressionSpecification = [
+    '/',
+    ['+', ['max', ['var', 'lum'], bgLum], 0.05],
+    ['+', ['min', ['var', 'lum'], bgLum], 0.05],
+  ];
+
+  const crAltExpr: ExpressionSpecification = [
+    '/',
+    ['+', ['max', ['var', 'lum'], altLum], 0.05],
+    ['+', ['min', ['var', 'lum'], altLum], 0.05],
+  ];
+
+  // Bind intermediate values, then pick the outline with the higher contrast
+  return [
+    'let',
+    'rgba',
+    ['to-rgba', routeColorExpr],
+    [
+      'let',
+      'lum',
+      lumExpr,
+      [
+        'let',
+        'crBg',
+        crBgExpr,
+        [
+          'let',
+          'crAlt',
+          crAltExpr,
+          [
+            'case',
+            ['>=', ['var', 'crBg'], ['var', 'crAlt']],
+            mapBgColor,
+            altOutlineColor,
+          ],
+        ],
+      ],
+    ],
+  ];
 }
 
 export const getBoundsFromCoordinates = (

--- a/src/app/components/GtfsVisualizationMap.layers.tsx
+++ b/src/app/components/GtfsVisualizationMap.layers.tsx
@@ -5,7 +5,10 @@ import {
   type ExpressionSpecification,
   type LayerSpecification,
 } from 'maplibre-gl';
-import { generateStopColorExpression } from './GtfsVisualizationMap.functions';
+import {
+  generateStopColorExpression,
+  generateRouteOutlineColorExpression,
+} from './GtfsVisualizationMap.functions';
 import { type Theme } from '@mui/material';
 
 // layer helpers
@@ -40,7 +43,6 @@ export const stopsBaseFilter = (
         ];
 };
 
-// layers
 export const RoutesWhiteLayer = (
   filteredRouteTypeIds: string[],
   theme: Theme,
@@ -52,8 +54,17 @@ export const RoutesWhiteLayer = (
     'source-layer': 'routesoutput',
     type: 'line',
     paint: {
-      'line-color': theme.palette.background.default,
-      'line-width': ['match', ['get', 'route_type'], '3', 10, '1', 15, 3],
+      'line-color': generateRouteOutlineColorExpression(
+        theme.map.basemapTileOverallColor ?? '#ffffff',
+        theme.palette.mode === 'light' ? theme.palette.grey[500] : '#ffffff1a',
+      ),
+      'line-opacity': 1,
+      'line-width': ['match', ['get', 'route_type'], '3', 5, '1', 10, 7],
+    },
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+      'line-sort-key': ['match', ['get', 'route_type'], '1', 3, '3', 2, 0],
     },
   };
 };
@@ -78,34 +89,50 @@ export const RouteLayer = (
           ['==', filteredRoutes.length, 0],
           ['in', ['get', 'route_id'], ['literal', filteredRoutes]],
         ],
-        0.4,
+        ['match', ['get', 'route_type'], '1', 0.8, '3', 0.4, 0.5],
         0.1,
       ],
     },
     layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
       'line-sort-key': ['match', ['get', 'route_type'], '1', 3, '3', 2, 0],
     },
   };
 };
 
-export const StopLayer = (
-  hideStops: boolean,
-  allSelectedRouteIds: string[],
-  stopRadius: number,
+export const RoutesWhiteHighlightLayer = (
+  routeId: string | undefined,
+  hoverInfo: string[],
+  filteredRoutes: string[],
+  theme: Theme,
 ): LayerSpecification => {
   return {
-    id: 'stops',
-    filter: stopsBaseFilter(hideStops, allSelectedRouteIds),
-    source: 'sample',
-    'source-layer': 'stopsoutput',
-    type: 'circle',
+    id: 'routes-white-highlight',
+    source: 'routes',
+    'source-layer': 'routesoutput',
+    type: 'line',
     paint: {
-      'circle-radius': stopRadius,
-      'circle-color': '#000000',
-      'circle-opacity': 0.4,
+      'line-color': generateRouteOutlineColorExpression(
+        theme.map.basemapTileOverallColor ?? '#ffffff',
+        theme.palette.mode === 'light'
+          ? theme.palette.grey[500]
+          : theme.palette.grey[200],
+      ),
+      'line-opacity': 1,
+      'line-width': ['match', ['get', 'route_type'], '3', 10, '1', 14, 10],
     },
-    minzoom: 12,
-    maxzoom: 22,
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+      'line-sort-key': ['match', ['get', 'route_type'], '1', 3, '3', 2, 0],
+    },
+    filter: [
+      'any',
+      ['in', ['get', 'route_id'], ['literal', hoverInfo]],
+      ['in', ['get', 'route_id'], ['literal', filteredRoutes]],
+      ['in', ['get', 'route_id'], ['literal', [routeId ?? '']]],
+    ],
   };
 };
 
@@ -133,12 +160,35 @@ export const RouteHighlightLayer = (
   };
 };
 
+export const StopLayer = (
+  hideStops: boolean,
+  allSelectedRouteIds: string[],
+  stopRadius: number,
+  theme: Theme,
+): LayerSpecification => {
+  return {
+    id: 'stops',
+    filter: stopsBaseFilter(hideStops, allSelectedRouteIds),
+    source: 'sample',
+    'source-layer': 'stopsoutput',
+    type: 'circle',
+    paint: {
+      'circle-radius': stopRadius,
+      'circle-color': theme.palette.text.primary,
+      'circle-opacity': 0.4,
+    },
+    minzoom: 12,
+    maxzoom: 22,
+  };
+};
+
 export const StopsHighlightLayer = (
   hoverInfo: string[],
   hideStops: boolean,
   filteredRoutes: string[],
   stopId: string | undefined,
   stopHighlightColorMap: Record<string, string>,
+  theme: Theme,
 ): LayerSpecification => {
   return {
     id: 'stops-highlight',
@@ -147,10 +197,14 @@ export const StopsHighlightLayer = (
     type: 'circle',
     paint: {
       'circle-radius': 7,
-      'circle-color': generateStopColorExpression(stopHighlightColorMap),
+      'circle-color': generateStopColorExpression(
+        stopHighlightColorMap,
+        theme.map.basemapTileOverallColor ?? '#ffffff',
+        theme.palette.text.primary,
+      ),
       'circle-opacity': 1,
     },
-    minzoom: 10,
+    minzoom: 11,
     maxzoom: 22,
     filter: hideStops
       ? !hideStops
@@ -198,6 +252,8 @@ export const StopsHighlightOuterLayer = (
       'circle-color': theme.palette.background.paper,
       'circle-opacity': 1,
     },
+    minzoom: 11,
+    maxzoom: 22,
     filter: hideStops
       ? !hideStops
       : [

--- a/src/app/components/GtfsVisualizationMap.layers.tsx
+++ b/src/app/components/GtfsVisualizationMap.layers.tsx
@@ -56,7 +56,7 @@ export const RoutesWhiteLayer = (
     paint: {
       'line-color': generateRouteOutlineColorExpression(
         theme.map.basemapTileOverallColor ?? '#ffffff',
-        theme.palette.mode === 'light' ? theme.palette.grey[500] : '#ffffff1a',
+        theme.palette.grey[500],
       ),
       'line-opacity': 1,
       'line-width': ['match', ['get', 'route_type'], '3', 5, '1', 10, 7],
@@ -115,9 +115,7 @@ export const RoutesWhiteHighlightLayer = (
     paint: {
       'line-color': generateRouteOutlineColorExpression(
         theme.map.basemapTileOverallColor ?? '#ffffff',
-        theme.palette.mode === 'light'
-          ? theme.palette.grey[500]
-          : theme.palette.grey[200],
+        theme.palette.grey[500],
       ),
       'line-opacity': 1,
       'line-width': ['match', ['get', 'route_type'], '3', 10, '1', 14, 10],
@@ -200,7 +198,7 @@ export const StopsHighlightLayer = (
       'circle-color': generateStopColorExpression(
         stopHighlightColorMap,
         theme.map.basemapTileOverallColor ?? '#ffffff',
-        theme.palette.text.primary,
+        theme.palette.grey[500],
       ),
       'circle-opacity': 1,
     },

--- a/src/app/components/GtfsVisualizationMap.spec.tsx
+++ b/src/app/components/GtfsVisualizationMap.spec.tsx
@@ -1,4 +1,149 @@
-import { generatePmtilesUrls } from './GtfsVisualizationMap.functions';
+import {
+  generatePmtilesUrls,
+  generateStopColorExpression,
+  generateRouteOutlineColorExpression,
+} from './GtfsVisualizationMap.functions';
+
+const LIGHT_BG = '#f6f6f6';
+const DARK_BG = '#0d0d0d';
+const LIGHT_ALT = '#444444';
+const DARK_ALT = '#ffffff';
+
+describe('generateStopColorExpression', () => {
+  it('returns fallback directly when routeIdToColor is empty', () => {
+    expect(generateStopColorExpression({}, LIGHT_BG, LIGHT_ALT, '#888')).toBe(
+      '#888',
+    );
+  });
+
+  it('skips entries with null or invalid hex colors and returns fallback', () => {
+    const result = generateStopColorExpression(
+      { r1: null as unknown as string, r2: 'gggggg', r3: '' },
+      LIGHT_BG,
+      LIGHT_ALT,
+    );
+    expect(result).toBe('#888');
+  });
+
+  it('expands 3-digit hex to 6-digit before comparison', () => {
+    // #000 → #000000 (black) — high contrast against light bg → route color wins
+    const result = generateStopColorExpression(
+      { r1: '000' },
+      LIGHT_BG,
+      LIGHT_ALT,
+    ) as unknown[];
+    expect(result[0]).toBe('case');
+    expect(result[2]).toBe('#000000');
+  });
+
+  it('uses route color when crBg >= crAlt (black route on light bg)', () => {
+    // crBg(black vs #f6f6f6) ≈ 20.3 >> crAlt(black vs #444444) ≈ 13.4 → route color wins
+    const result = generateStopColorExpression(
+      { route1: '000000' },
+      LIGHT_BG,
+      LIGHT_ALT,
+    ) as unknown[];
+    expect(result[0]).toBe('case');
+    expect(result[2]).toBe('#000000');
+  });
+
+  it('uses alt color when crAlt > crBg (white route on light bg)', () => {
+    // crBg(white vs #f6f6f6) ≈ 1.03 << crAlt(white vs #444444) ≈ 3.31 → alt wins
+    const result = generateStopColorExpression(
+      { route1: 'ffffff' },
+      LIGHT_BG,
+      LIGHT_ALT,
+    ) as unknown[];
+    expect(result[0]).toBe('case');
+    expect(result[2]).toBe(LIGHT_ALT);
+  });
+
+  it('uses alt color for dark route on dark map background', () => {
+    // crBg(black vs #0d0d0d) ≈ 2.02 << crAlt(black vs #ffffff) ≈ 21 → alt wins
+    const result = generateStopColorExpression(
+      { route1: '000000' },
+      DARK_BG,
+      DARK_ALT,
+    ) as unknown[];
+    expect(result[2]).toBe(DARK_ALT);
+  });
+
+  it('picks correct color independently per route', () => {
+    // r1=black → route color, r2=white → alt
+    const result = generateStopColorExpression(
+      { r1: '000000', r2: 'ffffff' },
+      LIGHT_BG,
+      LIGHT_ALT,
+    ) as unknown[];
+    expect(result[0]).toBe('case');
+    expect(result[2]).toBe('#000000'); // r1: route color
+    expect(result[4]).toBe(LIGHT_ALT); // r2: alt color
+    expect(result[5]).toBe('#888'); // fallback
+  });
+
+  it('includes the fallback as the last element of the case expression', () => {
+    const result = generateStopColorExpression(
+      { r1: '000000' },
+      LIGHT_BG,
+      LIGHT_ALT,
+      '#cccccc',
+    ) as unknown[];
+    expect(result[result.length - 1]).toBe('#cccccc');
+  });
+});
+
+describe('generateRouteOutlineColorExpression', () => {
+  // Helper to safely index into nested unknown arrays
+  type NestedArr = Array<unknown | NestedArr>;
+  const at = (arr: NestedArr, ...indices: number[]): NestedArr =>
+    indices.reduce<NestedArr>((a, i) => (a as NestedArr[])[i], arr);
+  it('returns an array expression starting with "let" and "rgba"', () => {
+    const result = generateRouteOutlineColorExpression(LIGHT_BG, LIGHT_ALT);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result[0]).toBe('let');
+    expect(result[1]).toBe('rgba');
+  });
+
+  it('embeds mapBgColor and altOutlineColor as the case outputs', () => {
+    const result = generateRouteOutlineColorExpression(LIGHT_BG, LIGHT_ALT);
+    // Navigate to the innermost case: result[3][3][3][3]
+    const caseExpr = at(result as NestedArr, 3, 3, 3, 3);
+    expect(caseExpr[0]).toBe('case');
+    expect(caseExpr[2]).toBe(LIGHT_BG); // chosen when crBg >= crAlt
+    expect(caseExpr[3]).toBe(LIGHT_ALT); // chosen when crAlt > crBg
+  });
+
+  it('embeds precomputed bgLum for the given mapBgColor in the crBg expression', () => {
+    const result = generateRouteOutlineColorExpression('#f6f6f6', LIGHT_ALT);
+    // bgLum for #f6f6f6: (246/255) ≈ 0.9647  (Rec. 709 coefficients sum to 1 for grey)
+    const expectedBgLum = (0.2126 * 246 + 0.7152 * 246 + 0.0722 * 246) / 255;
+    // structure: result[3]=['let','lum',...,innerCrBg], result[3][3]=['let','crBg',crBgExpr,...]
+    // crBgExpr = ['/', ['+', ['max', ['var','lum'], bgLum], 0.05], ...]
+    // bgLum appears at crBgExpr[1][1][2]
+    const crBgExpr = at(result as NestedArr, 3, 3, 2);
+    const bgLumInExpr = at(crBgExpr, 1, 1)[2] as number;
+    expect(bgLumInExpr).toBeCloseTo(expectedBgLum, 10);
+  });
+
+  it('works for dark mode colors without error', () => {
+    expect(() =>
+      generateRouteOutlineColorExpression(DARK_BG, DARK_ALT),
+    ).not.toThrow();
+  });
+
+  it('uses different precomputed luminance values for light vs dark bg', () => {
+    const lightResult = generateRouteOutlineColorExpression(
+      LIGHT_BG,
+      LIGHT_ALT,
+    );
+    const darkResult = generateRouteOutlineColorExpression(DARK_BG, DARK_ALT);
+    const crBgLight = at(lightResult as NestedArr, 3, 3, 2);
+    const crBgDark = at(darkResult as NestedArr, 3, 3, 2);
+    const bgLumLight = at(crBgLight, 1, 1)[2] as number;
+    const bgLumDark = at(crBgDark, 1, 1)[2] as number;
+    expect(bgLumLight).toBeGreaterThan(bgLumDark);
+  });
+});
 
 describe('generatePmtilesUrls', () => {
   const latestDataset = {

--- a/src/app/components/GtfsVisualizationMap.tsx
+++ b/src/app/components/GtfsVisualizationMap.tsx
@@ -32,6 +32,7 @@ import {
 import {
   RouteHighlightLayer,
   RouteLayer,
+  RoutesWhiteHighlightLayer,
   RoutesWhiteLayer,
   StopLayer,
   StopsHighlightLayer,
@@ -590,7 +591,13 @@ export const GtfsVisualizationMap = ({
                 },
                 RoutesWhiteLayer(filteredRouteTypeIds, theme),
                 RouteLayer(filteredRoutes, filteredRouteTypeIds),
-                StopLayer(hideStops, allSelectedRouteIds, stopRadius),
+                RoutesWhiteHighlightLayer(
+                  mapClickRouteData?.route_id,
+                  hoverInfo,
+                  filteredRoutes,
+                  theme,
+                ),
+                StopLayer(hideStops, allSelectedRouteIds, stopRadius, theme),
                 RouteHighlightLayer(
                   mapClickRouteData?.route_id,
                   hoverInfo,
@@ -602,6 +609,7 @@ export const GtfsVisualizationMap = ({
                   filteredRoutes,
                   mapClickStopData?.stop_id,
                   stopHighlightColorMap,
+                  theme,
                 ),
                 StopsHighlightOuterLayer(
                   hoverInfo,

--- a/src/app/screens/Feed/components/FullMapView.tsx
+++ b/src/app/screens/Feed/components/FullMapView.tsx
@@ -178,7 +178,7 @@ export default function FullMapView({
           variant='outlined'
           size='small'
           key={routeTypeId}
-          label={getRouteTypeTranslatedName(routeTypeId, t)}
+          label={getRouteTypeTranslatedName(routeTypeId, tCommon)}
           onDelete={() => {
             setFilteredRouteTypeIds((prev) =>
               prev.filter((type) => type !== routeTypeId),


### PR DESCRIPTION
**Summary:**

closes #65 

The gtfs map visualization did not properly support color contrast on light / dark mode maps. This lead to white routes being unreadable on light map, and dark routes being unreadable on dark maps

This PR introduces a contrast check between the route color and the map background, which also applies to the stop elements

Also includes map enhancements
- Stops now only appear at a closer zoom
- Highlighting a route increases its visibility
- Rounded edges for routes

**Expected behavior:** 

When you go on a map that has route colors that have low contrast with the map background, there should be halo lines to help with the contrast. ex:
https://mobilitydatabase-web-git-fix-65-map-colors-mobility-data.vercel.app/feeds/gtfs/mdb-2126/map
https://mobilitydatabase-web-git-fix-65-map-colors-mobility-data.vercel.app/feeds/gtfs/mdb-437/map

these aren't the most clear cut examples as there are limited feeds with visualization in dev environment but you still see the contrast coming out: (STM: the yellow metro line)

**Testing tips:**

Go on feeds with gtfs visualization and assure that the map feels good and that the colors have proper contrast

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `yarn test` to make sure you didn't break anything
- [ ] Add or update any needed documentation to the repo
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
- [X] Include screenshot(s) showing how this pull request works and fixes the issue(s)

Before
<img width="1607" height="1059" alt="image" src="https://github.com/user-attachments/assets/82c29d4d-0750-4f63-95d2-635dec8947f0" />
After
<img width="1589" height="1017" alt="image" src="https://github.com/user-attachments/assets/b74575e8-0ac3-4aae-8caf-208f040936c2" />

Before
<img width="758" height="1035" alt="image" src="https://github.com/user-attachments/assets/a4faf767-6850-40d1-b567-da6146966308" />
After
<img width="536" height="815" alt="image" src="https://github.com/user-attachments/assets/d9d08923-bb79-4c4d-ae90-9ec4192473f2" />


Before (rounding)
<img width="986" height="562" alt="image" src="https://github.com/user-attachments/assets/35f2e29c-395a-486c-a1b5-d0b94cb3f28f" />
After
<img width="1105" height="598" alt="Screenshot 2026-04-10 at 10 53 14" src="https://github.com/user-attachments/assets/99523818-7cb5-4836-9be6-fa2de999e3a9" />

Before (stop zoom)
<img width="897" height="538" alt="image" src="https://github.com/user-attachments/assets/5f607c04-1def-41de-a272-a9c15a980cd7" />
After
<img width="869" height="583" alt="Screenshot 2026-04-10 at 10 55 02" src="https://github.com/user-attachments/assets/5cf4e44d-2853-4000-8619-226e06e46e4c" />

Stops Contrast Highlights
<img width="1021" height="529" alt="Screenshot 2026-04-10 at 10 57 04" src="https://github.com/user-attachments/assets/28834f5c-093d-4498-bc72-d2009d7026e2" />

<img width="1131" height="516" alt="Screenshot 2026-04-10 at 10 56 57" src="https://github.com/user-attachments/assets/d7a6521b-9d2b-407d-bca6-37816679587e" />



